### PR TITLE
Fix error when bundle file have directories

### DIFF
--- a/internal/utils/file_utils.go
+++ b/internal/utils/file_utils.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"path/filepath"
 )
 
 func ExtractTarGz(gzipStream io.Reader) error {
@@ -40,8 +41,18 @@ func ExtractTarGz(gzipStream io.Reader) error {
 		case tar.TypeReg:
 			outFile, err := os.Create(header.Name)
 			if err != nil {
-				//log.Fatalf("ExtractTarGz: Create() failed: %s", err.Error())
-				return errors.New("ExtractTarGz: NewReader failed")
+				// We were unable to create the file because there was no
+				// Tar Directory entry coresponding to this file's directory.
+				// Let's try to create the directory and try again.
+				if err = os.MkdirAll(filepath.Dir(header.Name), 0755); err != nil {
+					// log.Fatalf("ExtractTarGz: Create() failed: %s", err.Error())
+					return errors.New("ExtractTarGz: NewReader failed")
+				}
+				outFile, err = os.Create(header.Name)
+				if err != nil {
+					// log.Fatalf("ExtractTarGz: Create() failed: %s", err.Error())
+					return errors.New("ExtractTarGz: NewReader failed")
+				}
 
 			}
 			defer outFile.Close()

--- a/internal/utils/file_utils.go
+++ b/internal/utils/file_utils.go
@@ -34,7 +34,6 @@ func ExtractTarGz(gzipStream io.Reader) error {
 		switch header.Typeflag {
 		case tar.TypeDir:
 			if err := os.Mkdir(header.Name, 0755); err != nil {
-				//log.Fatalf("ExtractTarGz: Mkdir() failed: %s", err.Error())
 				return errors.New("ExtractTarGz: NewReader failed")
 
 			}
@@ -45,19 +44,16 @@ func ExtractTarGz(gzipStream io.Reader) error {
 				// Tar Directory entry coresponding to this file's directory.
 				// Let's try to create the directory and try again.
 				if err = os.MkdirAll(filepath.Dir(header.Name), 0755); err != nil {
-					// log.Fatalf("ExtractTarGz: Create() failed: %s", err.Error())
 					return errors.New("ExtractTarGz: NewReader failed")
 				}
 				outFile, err = os.Create(header.Name)
 				if err != nil {
-					// log.Fatalf("ExtractTarGz: Create() failed: %s", err.Error())
 					return errors.New("ExtractTarGz: NewReader failed")
 				}
 
 			}
 			defer outFile.Close()
 			if _, err := io.Copy(outFile, tarReader); err != nil {
-				//log.Fatalf("ExtractTarGz: Copy() failed: %s", err.Error())
 				return errors.New("ExtractTarGz: NewReader failed")
 
 			}


### PR DESCRIPTION
The .tar.gz bundle file that is downloaded from the server can now embbed
directories but it does not contains TAR header entries for
directories.

This lead to attempt to extract files to directories that are not
created.

This commit aims at doing a fallback: if a file fails to be created, we
first try to create it's directory, regardless of if there was or not a
TAR directory header.